### PR TITLE
Add Amplify Preview Workflow

### DIFF
--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -14,6 +14,25 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    # Set up AWS CLI
+    - name: Set up AWS CLI
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    # Check if branch exists in Amplify
+    - name: Check if branch exists
+      id: checkbranch
+      run: |
+        EXISTS=$(aws amplify list-branches --app-id ${{ secrets.AMPLIFYAPPID }} | jq '.branches[] | select(.branchName=="${{ steps.setenvname.outputs.setbranchname }}")')
+        if [[ -z "$EXISTS" ]]; then
+          echo "##[set-output name=branchExists;]false"
+        else
+          echo "##[set-output name=branchExists;]true"
+        fi
+
     # Amplify Preview Deployment
     - name: Set branch name environment variable
       id: setenvname
@@ -21,6 +40,7 @@ jobs:
         echo "##[set-output name=setbranchname;]$(echo ${GITHUB_HEAD_REF})"
       
     - name: Deploy PR preview
+      if: steps.checkbranch.outputs.branchExists == 'false'
       uses: yinlinchen/amplify-preview-actions@master
       with:
         branch_name: ${{ steps.setenvname.outputs.setbranchname }}
@@ -30,6 +50,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
-        # BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
+        BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
         # EnvironmentVariables: 'key1=value,key2=value' # If you have any environment variables
         AWS_REGION: 'us-east-1'

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -1,0 +1,35 @@
+name: Amplify PR Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    # Amplify Preview Deployment
+    - name: Set branch name environment variable
+      id: setenvname
+      run: |
+        echo "##[set-output name=setbranchname;]$(echo ${GITHUB_HEAD_REF})"
+      
+    - name: Deploy PR preview
+      uses: yinlinchen/amplify-preview-actions@master
+      with:
+        branch_name: ${{ steps.setenvname.outputs.setbranchname }}
+        amplify_command: deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
+        BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
+        # EnvironmentVariables: 'key1=value,key2=value' # If you have any environment variables
+        AWS_REGION: 'us-east-1'

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -30,6 +30,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
-        BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
+        # BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
         # EnvironmentVariables: 'key1=value,key2=value' # If you have any environment variables
         AWS_REGION: 'us-east-1'

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -50,6 +50,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
-        BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
+        # BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
         # EnvironmentVariables: 'key1=value,key2=value' # If you have any environment variables
         AWS_REGION: 'us-east-1'

--- a/.github/workflows/amplify-preview.yaml
+++ b/.github/workflows/amplify-preview.yaml
@@ -30,6 +30,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AmplifyAppId: ${{ secrets.AMPLIFYAPPID }}
-        # BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
+        BackendEnvARN: ${{ secrets.BACKENDENVARN }} # If applicable
         # EnvironmentVariables: 'key1=value,key2=value' # If you have any environment variables
         AWS_REGION: 'us-east-1'


### PR DESCRIPTION
#### Overall Review of Changes:
Added a new workflow for getting public PR previews for AWS Amplify. 

##### Reason for Change
Amplify does not support PR previews for public repositories, so this workflow is a workaround. 

#### Tested:
No
