### PR TITLE
Noah/add support and settings pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,5 @@
+
+
 {
   "name": "unipath.io",
   "version": "0.1.0",

--- a/src/app/(home)/Drawer.js
+++ b/src/app/(home)/Drawer.js
@@ -43,12 +43,23 @@ export default function DrawerComponent({ drawerWidth, open, handleDrawerClose, 
     const [pathwaysOpen, setPathwaysOpen] = useState(true);
     const [tasksOpen, setTasksOpen] = useState(true);
 
+    const [settingsOpen, setSettingsOpen] = useState(true);
+    const [supportOpen, setSupportOpen] = useState(true);
+  
     const handlePathwaysClick = () => {
         setPathwaysOpen(!pathwaysOpen);
     };
 
     const handleTasksClick = () => {
         setTasksOpen(!tasksOpen);
+    };
+
+    const handleSettingsClick = () => {
+        setSettingsOpen(!settingsOpen);
+    };
+
+    const handleSupportClick = () => {
+        setSupportOpen(!supportOpen);
     };
 
     return (
@@ -126,7 +137,7 @@ export default function DrawerComponent({ drawerWidth, open, handleDrawerClose, 
             <Divider />
 
             <List>
-                <ListItemButton>
+                <ListItemButton onClick={handleSupportClick} href='/support' selected={pathname === '/support'}>
                     <ListItemIcon>
                         <SupportIcon />
                     </ListItemIcon>
@@ -138,7 +149,7 @@ export default function DrawerComponent({ drawerWidth, open, handleDrawerClose, 
                     </ListItemIcon>
                     <ListItemText primary="Home Page" href='/#' />
                 </ListItemButton>
-                <ListItemButton>
+                <ListItemButton onClick={handleSettingsClick} href='/settings' selected={pathname === '/settings'}>
                     <ListItemIcon>
                         <SettingsIcon />
                     </ListItemIcon>

--- a/src/app/(home)/settings/page.js
+++ b/src/app/(home)/settings/page.js
@@ -1,0 +1,31 @@
+// React
+import * as React from 'react';
+
+// Material UI
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import CssBaseline from '@mui/material/CssBaseline';
+import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+
+
+export default function SettingsPage() {
+    return (
+        <Box>
+            <Typography variant="body1" gutterBottom>
+                Settings page
+            </Typography>
+        </Box>
+    );
+    }
+
+  

--- a/src/app/(home)/settings/page.js
+++ b/src/app/(home)/settings/page.js
@@ -2,19 +2,9 @@
 import * as React from 'react';
 
 // Material UI
-import Avatar from '@mui/material/Avatar';
-import Button from '@mui/material/Button';
-import CssBaseline from '@mui/material/CssBaseline';
-import TextField from '@mui/material/TextField';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import Link from '@mui/material/Link';
-import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
-import Container from '@mui/material/Container';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+
 
 
 

--- a/src/app/(home)/support/page.js
+++ b/src/app/(home)/support/page.js
@@ -2,19 +2,8 @@
 import * as React from 'react';
 
 // Material UI
-import Avatar from '@mui/material/Avatar';
-import Button from '@mui/material/Button';
-import CssBaseline from '@mui/material/CssBaseline';
-import TextField from '@mui/material/TextField';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import Link from '@mui/material/Link';
-import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
-import Container from '@mui/material/Container';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 
 

--- a/src/app/(home)/support/page.js
+++ b/src/app/(home)/support/page.js
@@ -1,0 +1,31 @@
+// React
+import * as React from 'react';
+
+// Material UI
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import CssBaseline from '@mui/material/CssBaseline';
+import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+
+
+export default function SupportPage() {
+    return (
+        <Box>
+            <Typography variant="body1" gutterBottom>
+                Support page
+            </Typography>
+        </Box>
+    );
+    }
+
+  


### PR DESCRIPTION
#### Overall Review of Changes:
Added functionality to go to the settings and support pages. To do this, I created the folders "settings" and "support" and then put a "page.js" file in each of them. I then connected these pages through the "Drawer.js" file.

##### Reason for Change
We need a settings and support page.

#### Tested:
Yes
