### PR TITLE
Added database persistance to Pathway creation

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -8,9 +8,10 @@ specify that owners, authenticated via your Auth resource can "create",
 authenticated via an API key, can only "read" records.
 =========================================================================*/
 const schema = a.schema({
-    Todo: a
+    Pathway: a
         .model({
-            content: a.string(),
+            title: a.string(),
+            degree: a.string(),
         })
         .authorization([a.allow.owner(), a.allow.public().to(['read'])]),
 });

--- a/src/app/(home)/pathways/mockData.js
+++ b/src/app/(home)/pathways/mockData.js
@@ -85,7 +85,7 @@ export const pathwayData = {
       "degree": "Bachelor of Science",
     },
     {
-      "title": "Computer Engineering",
+      "title": "Mechanical Engineering",
       "degree": "Bachelor of Engineering",
     }
   ]


### PR DESCRIPTION
#### Overall Review of Changes:
- added database persistance to Pathway creation
- Added a simple Pathway Data Model
- Figured out how Amplify associates users to Data Model.
- Explored what AuthorizationModes are. Used the correct auth mode for AppSync generateClient()
##### Reason for Change
- Exploring how to use the backend. Breaking into previously uncharted territory.
#### Tested:
visually

Client view:
![databasePersistanceUIView](https://github.com/UMLCloudComputing/UniPath.io/assets/109564679/15423d96-60a2-4c76-90ae-a08dba656852)

DynamoDB view:
![image](https://github.com/UMLCloudComputing/UniPath.io/assets/109564679/e1c4255d-0451-4cf3-8dee-cf800de2a092)

