### PR TITLE
Implement NextJS auth and redirect page

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -27,7 +27,6 @@ const schema = a.schema({
         credits: a.integer(),
         grade: a.string()
     }).authorization([a.allow.owner(), a.allow.public().to(['read'])])
-
 });
 
 export type Schema = ClientSchema<typeof schema>;

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "MAIN/*": ["./*"]
-    }
+    },
+    "resolveJsonModule": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "unipath.io",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-amplify/adapter-nextjs": "^1.0.21",
         "@aws-amplify/cli": "^12.7.1",
         "@aws-amplify/ui-react": "^6.0.3",
         "@emotion/cache": "^11.11.0",
@@ -296,6 +297,18 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-amplify/adapter-nextjs": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/adapter-nextjs/-/adapter-nextjs-1.0.21.tgz",
+      "integrity": "sha512-Y38Bo8Z1cxUyMY0wPhlXWwR9oLWrS+R/225AJN0bd0JrWJeFvZmL+rD6zF3PA1WPU6hwBa7cEQxnhmKgaejdTg==",
+      "dependencies": {
+        "cookie": "0.5.0"
+      },
+      "peerDependencies": {
+        "aws-amplify": "^6.0.7",
+        "next": ">=13.5.0 <15.0.0"
       }
     },
     "node_modules/@aws-amplify/analytics": {
@@ -15335,6 +15348,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-js": {
       "version": "3.35.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aws-amplify/adapter-nextjs": "^1.0.21",
     "@aws-amplify/cli": "^12.7.1",
     "@aws-amplify/ui-react": "^6.0.3",
     "@emotion/cache": "^11.11.0",

--- a/src/app/(auth)/auth-redirect/page.js
+++ b/src/app/(auth)/auth-redirect/page.js
@@ -1,0 +1,31 @@
+"use client"
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import {usePathname, useSearchParams, useRouter} from "next/navigation";
+import {CircularProgress} from "@mui/material";
+
+export default function AuthRedirectPage() {
+    const router = useRouter()
+    const nextQuery = useSearchParams()
+    const redirectPage = nextQuery.get("next")
+
+    setTimeout(() => {
+        router.replace(`/login?next=${redirectPage}`)
+    }, 3000
+    )
+    return (
+        <Box sx={{display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "75vh"}}
+        >
+            <Typography>
+                You must be signed in to access this page. Redirecting to login...
+
+            </Typography>
+            <CircularProgress
+                disableShrink
+            sx={{
+                mt: 4
+            }}
+            />
+        </Box>
+    )
+}

--- a/src/app/(auth)/login/page.js
+++ b/src/app/(auth)/login/page.js
@@ -3,23 +3,28 @@
 import * as React from "react";
 
 // Next.js
-import { useRouter } from "next/navigation";
+import {useRouter, useSearchParams} from "next/navigation";
 
 // AWS
-import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
+import {Authenticator, useAuthenticator, withAuthenticator} from "@aws-amplify/ui-react";
 
 // Page: SignInPage;
-export default function SignInPage() {
+function SignInPage({user, signOut}) {
     const router = useRouter();
+    const nextQuery = useSearchParams()
+    const redirectPage = nextQuery.get("next")
 
     const { route } = useAuthenticator((context) => [context.route]);
     React.useEffect(() => {
         if (route === "authenticated") {
-            router.replace("/home");
+            router.replace(redirectPage || "/");
         }
-    }, [route, router]);
+    }, [route, router, redirectPage]);
 
     return <Authenticator
         socialProviders={["google"]}
         initialState={"signIn"} />;
+
 }
+
+export default SignInPage

--- a/src/app/(home)/pathways/page.js
+++ b/src/app/(home)/pathways/page.js
@@ -19,7 +19,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 
 // Local
 import Accordion from '@/components/Accordions/SemesterAccordion';
-// src/components/Accordions/SemesterAccordion.js 
+// src/components/Accordions/SemesterAccordion.js
 import PathwayDialog from '@/components/Dialogs/PathwayDialog.js';
 // is this the right pathway dialog - Rohan M?
 
@@ -46,51 +46,37 @@ export default function PathwaysPage() {
     const [editingPathway, setEditingPathway] = useState({});
 
 
-    const { user, authStatus } = useAuthenticator();
     const client = generateClient({ authMode: 'userPool'})
 
     const router = useRouter();
 
-    const fetchPathways = async () => {
+    const fetchPathways = () => {
         setLoading(true)
         client.models.Pathway.list().then(({ data, errors}) => {
             errors ? console.error(errors) : // retrieving data from DynamoDB and checking for errors
                 setPathways(data);
-            console.log("Pathways from Database:", data)
             setLoading(false);
         })
     }
 
 
     useEffect(() => {
-        if (authStatus === 'authenticated') {
-            fetchPathways()
-        } else if (authStatus === 'unauthenticated') {
-            router.push('/login');
-        }
-    }, [authStatus])
+        fetchPathways()
+    }, [])
 
-    const handleEdit = async (id, editedFields) => {
-        const newPathway = {
-            id: id,
-            name: editedFields.newName,
-            degree: editedFields.newDegree,
-            institution: editedFields.newInstitution,
-            yog: editedFields.newYOG,
-            degreeLevel: editedFields.newDegreeLevel
-        }
-        await client.models.Pathway.update(newPathway);
-        await fetchPathways()
+    const handleEdit = async (editedFields) => {
+        await client.models.Pathway.update(editedFields);
+        fetchPathways()
 
     }
     const handleDelete = async (id) => {
         await client.models.Pathway.delete({id: id});
-        await fetchPathways()
+        fetchPathways()
     }
 
     const handleCreate = async (fields) => {
         await client.models.Pathway.create(fields);
-        await fetchPathways()
+        fetchPathways()
     }
 
     const handleEditDialogOpen = () => {
@@ -113,92 +99,91 @@ export default function PathwaysPage() {
     return (<Box>
 
 
-        {/*Popup Dialog*/}
-        <PathwayDialog
-            open={createDialogOpen}
-            handleClose={handleCreateDialogClose}
-            handleCreate={handleCreate}
-        />
-        <EditPathwayDialog
-            open={editDialogOpen}
-            handleClose={handleEditDialogClose}
-            handleEditPathway={handleEdit}
-            pathway={editingPathway}
-        />
-        {/*Heading*/}
-        <Box
-            component="header"
-            sx={{
-                mb: 2,
-            }}
-        >
-            <Typography variant="h4">My Pathways</Typography>
-        </Box>
-
-        {/*Loading state (below heading)*/}
-        {
-            loading ? (
-                <Box sx={{ width: '100%' }}>
-                    <LinearProgress />
-                </Box>
-            ) : (
-                <></>
-            )
-        }
-
-
-        {
-            pathways.length === 0 ?
-
-                <NoPathways/>
-                :
-                <Box>
-
-
-                    {/*Pathway Cards*/}
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexWrap: 'wrap',
-                            width: '100%',
-                            gap: 4,
-                        }}
-                    >
-                        {
-                            pathways.map((pathway, index) => {
-                                return (
-                                    <PathwayCard
-                                        key={index}
-                                        pathway={pathway}
-                                        handleEditDialogOpen={handleEditDialogOpen}
-                                        handlePathwayDelete={handleDelete}
-                                        handleSetEditingPathway={setEditingPathway}
-                                    />
-                                )
-                            })
-                        }
-                    </Box>
-
-
-                </Box>
-        }
-        {/*Bottom right corner*/}
-        <IconButton
-            onClick={handleCreateDialogOpen}
-        >
-            <AddCircleOutlineIcon
-                sx={{
-                    position: 'fixed',
-                    bottom: '4%',
-                    right: '4%',
-                    fontSize: '40px',
-                    color: theme.palette.primary.main,
-                }}
+            {/*Popup Dialog*/}
+            <PathwayDialog
+                open={createDialogOpen}
+                handleClose={handleCreateDialogClose}
+                handleCreate={handleCreate}
             />
-        </IconButton>
-    </Box>
+            <EditPathwayDialog
+                open={editDialogOpen}
+                handleClose={handleEditDialogClose}
+                handleEditPathway={handleEdit}
+                pathway={editingPathway}
+            />
+            {/*Heading*/}
+            <Box
+                component="header"
+                sx={{
+                    mb: 2,
+                }}
+            >
+                <Typography variant="h4">My Pathways</Typography>
+            </Box>
+
+            {/*Loading state (below heading)*/}
+            {
+                loading ? (
+                    <Box sx={{ width: '100%' }}>
+                        <LinearProgress />
+                    </Box>
+                ) : (
+                    <></>
+                )
+            }
+
+
+            {
+                pathways.length === 0 ?
+
+                    <NoPathways/>
+                    :
+                    <Box>
+
+
+                        {/*Pathway Cards*/}
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                flexWrap: 'wrap',
+                                width: '100%',
+                                gap: 4,
+                            }}
+                        >
+                            {
+                                pathways.map((pathway, index) => {
+                                    return (
+                                        <PathwayCard
+                                            key={index}
+                                            pathway={pathway}
+                                            handleEditDialogOpen={handleEditDialogOpen}
+                                            handlePathwayDelete={handleDelete}
+                                            handleSetEditingPathway={setEditingPathway}
+                                        />
+                                    )
+                                })
+                            }
+                        </Box>
+
+
+                    </Box>
+            }
+            {/*Bottom right corner*/}
+            <IconButton
+                onClick={handleCreateDialogOpen}
+            >
+                <AddCircleOutlineIcon
+                    sx={{
+                        position: 'fixed',
+                        bottom: '4%',
+                        right: '4%',
+                        fontSize: '40px',
+                        color: theme.palette.primary.main,
+                    }}
+                />
+            </IconButton>
+        </Box>
 
     )
 }
-
 

--- a/src/app/(landing)/page.js
+++ b/src/app/(landing)/page.js
@@ -26,42 +26,6 @@ export default function LandingPage() {
         <Box>
             {/* AppBar */}
             <AppBarComponent isLandingPage={true}/>
-            {/*<AppBar position="static" color="transparent" elevation={0}>*/}
-            {/*    <Toolbar>*/}
-            {/*        /!* Logo *!/*/}
-            {/*        <img*/}
-            {/*            src="/favicon.png"*/}
-            {/*            alt="UniPath.io Logo"*/}
-            {/*            style={{ height: "50px", marginRight: "10px" }}*/}
-            {/*        />*/}
-            {/*        <Typography*/}
-            {/*            variant="h6"*/}
-            {/*            noWrap*/}
-            {/*            sx={{*/}
-            {/*                mr: 2,*/}
-            {/*                display: { xs: "none", md: "flex" },*/}
-            {/*            }}*/}
-            {/*        >*/}
-            {/*            UniPath.io*/}
-            {/*        </Typography>*/}
-
-            {/*        /!* This pushes everything after it to the right *!/*/}
-            {/*        <Box sx={{ flexGrow: 1 }} />*/}
-
-            {/*        /!* Buttons *!/*/}
-            {/*        <Box>*/}
-            {/*            <Button color="inherit" href="/home">*/}
-            {/*                About*/}
-            {/*            </Button>*/}
-            {/*            <Button color="inherit" href="/signin">*/}
-            {/*                Login*/}
-            {/*            </Button>*/}
-            {/*            <Button color="inherit" href="/signup">*/}
-            {/*                Sign Up*/}
-            {/*            </Button>*/}
-            {/*        </Box>*/}
-            {/*    </Toolbar>*/}
-            {/*</AppBar>*/}
 
             {/* Hero Section */}
             <Box sx={{p: {xs: 3, sm: 5, md: 10}}}>

--- a/src/app/api/pathway/route.js
+++ b/src/app/api/pathway/route.js
@@ -1,0 +1,24 @@
+import {generateClient} from "aws-amplify/data";
+import {NextResponse} from "next/server";
+import {fetchAuthSession, getCurrentUser} from "aws-amplify/auth";
+import {generateServerClientUsingCookies} from "@aws-amplify/adapter-nextjs/api";
+import amplifyConfig from "MAIN/amplifyconfiguration.json" assert {type: "json"};
+import {cookies} from "next/headers";
+import {cookieBasedClient} from "@/utils/amplifyServerUtils";
+
+export async function GET(request) {
+    const res = await fetchPathways()
+    return NextResponse.json({data: res.pathways, errors: res.errors});
+}
+
+export async function POST(request) {
+    console.log(JSON.stringify(request.body))
+    return NextResponse.json({data: "POST request received"});
+}
+
+
+const fetchPathways = async () => {
+    const {data: pathways, errors} = await cookieBasedClient.models.Pathway.list();
+    return {pathways, errors};
+
+}

--- a/src/components/Auth/isAuth.js
+++ b/src/components/Auth/isAuth.js
@@ -1,0 +1,16 @@
+import {useAuthenticator} from '@aws-amplify/ui-react';
+import {usePathname, useRouter, useSearchParams} from 'next/navigation'
+
+export const IsAuth = () => {
+    const {authStatus} = useAuthenticator();
+    const router = useRouter();
+    const currentPage = usePathname()
+
+    if (authStatus !== 'authenticated')
+    {
+        router.push('/login?next=' + currentPage)
+        return false
+    } else {
+        return true;
+    }
+}

--- a/src/components/Buttons/GoToPathwayButton.js
+++ b/src/components/Buttons/GoToPathwayButton.js
@@ -1,0 +1,17 @@
+"use client"
+
+import IconButton from "@mui/material/IconButton";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import React from "react";
+
+export const GoToPathwayButton = ({handlePathwayOptionsOpen}) => {
+    return (
+        <IconButton
+            sx={{
+                ml: 'auto'
+            }}
+            onClick={handlePathwayOptionsOpen}>
+            <MoreVertIcon/>
+        </IconButton>
+    )
+}

--- a/src/components/Cards/PathwayCard.js
+++ b/src/components/Cards/PathwayCard.js
@@ -7,7 +7,6 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import {useTheme} from '@mui/material/styles';
 import Card from '@mui/material/Card';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
 import SchoolIcon from '@mui/icons-material/School';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import PathIcon from "@mui/icons-material/Map";
@@ -18,13 +17,14 @@ import Menu from "@mui/material/Menu";
 //React
 import React from 'react';
 import MenuItem from "@mui/material/MenuItem";
+import {GoToPathwayButton} from "@/components/Buttons/GoToPathwayButton";
 
 
 export default function PathwayCard({
                                         pathway,
                                         handleEditDialogOpen,
                                         handlePathwayDelete,
-    handleSetEditingPathway
+                                        handleSetEditingPathway
                                     }) {
     const theme = useTheme();
     const [anchorEl, setAnchorEl] = React.useState(null);
@@ -117,13 +117,7 @@ export default function PathwayCard({
                         >
                             {pathway.name}
                         </Typography>
-                        <IconButton
-                            sx={{
-                                ml: 'auto'
-                            }}
-                            onClick={handlePathwayOptionsOpen}>
-                            <MoreVertIcon/>
-                        </IconButton>
+                        <GoToPathwayButton handlePathwayOptionsOpen={handlePathwayOptionsOpen}/>
 
 
                     </Box>

--- a/src/components/Dialogs/EditPathwayDialog.js
+++ b/src/components/Dialogs/EditPathwayDialog.js
@@ -1,3 +1,4 @@
+
 import React from "react";
 import Dialog from "@mui/material/Dialog";
 import {v4 as uuid} from "uuid";
@@ -14,8 +15,24 @@ import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import Chip from "@mui/material/Chip";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
+import {generateClient} from "aws-amplify/data";
 
 export default function EditPathwayDialog({open, handleClose, handleEditPathway, pathway}) {
+    // const client = generateClient({authMode: 'userPool'});
+    //
+    // async function handleEdit(formData) {
+    //     "use server"
+    //     const rawFormData = {
+    //         id: formData.id,
+    //         name: formData.name,
+    //         degree: formData.degree,
+    //         institution: formData.institution,
+    //         yog: formData.yog,
+    //         degreeLevel: formData.degreeLevel
+    //     }
+    //
+    //     await client.models.Pathway.update(rawFormData);
+    // }
 
 
     return (
@@ -23,6 +40,7 @@ export default function EditPathwayDialog({open, handleClose, handleEditPathway,
         <Dialog
             open={open}
             onClose={handleClose}
+            // action={handleEdit}
             PaperProps={{
                 component: 'form',
                 onSubmit: (e) => {
@@ -35,7 +53,7 @@ export default function EditPathwayDialog({open, handleClose, handleEditPathway,
                     const newYOG = formJson.yearOfGrad;
                     const newDegreeLevel = formJson.degreeType;
 
-                    handleEditPathway(pathway.id, {newName, newDegree, newInstitution, newYOG, newDegreeLevel})
+                    handleEditPathway({id: pathway.id, name: newName, degree: newDegree, institution: newInstitution, yog: newYOG, degreeLevel: newDegreeLevel});
                     handleClose();
                 }
 
@@ -103,9 +121,6 @@ export default function EditPathwayDialog({open, handleClose, handleEditPathway,
                     variant="standard"
                     defaultValue={pathway.degreeLevel}
                 />
-
-
-
 
             </DialogContent>
             <DialogActions>

--- a/src/components/Dialogs/PathwayDialog.js
+++ b/src/components/Dialogs/PathwayDialog.js
@@ -1,4 +1,4 @@
-
+"use client"
 //React
 import * as React from 'react';
 
@@ -24,7 +24,7 @@ import Chip from '@mui/material/Chip';
 
 
 //TODO: function to add course requirements to pathway
-export default function PathwayDialog({ open, handleClose, handleCreate}) {
+export default function PathwayDialog({open, handleClose, handleCreate}) {
 
   // State to manage the expanded/collapsed state of the accordion
   const [expanded, setExpanded] = React.useState(true);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -26,7 +26,7 @@ export async function middleware(request) {
     }
     else if (!authenticated && !request.nextUrl.pathname.startsWith('/login')) {
         console.log('Not authenticated');
-        return NextResponse.redirect(new URL(`/login?next=${redirectPage}`, request.url))
+        return NextResponse.redirect(new URL(`/auth-redirect?next=${redirectPage}`, request.url))
     }
 }
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,37 @@
+import {NextResponse} from "next/server";
+import {runWithAmplifyServerContext} from "@/utils/amplifyServerUtils";
+import {fetchAuthSession} from "aws-amplify/auth/server";
+
+export async function middleware(request) {
+    const response = NextResponse.next()
+    const redirectPage = request.nextUrl.pathname;
+
+    const authenticated = await runWithAmplifyServerContext({
+        nextServerContext: {request, response},
+        operation: async (contextSpec) => {
+            try {
+                const session = await fetchAuthSession(contextSpec)
+                return session.tokens !== undefined
+            } catch (error) {
+                console.log(error)
+                return false
+            }
+        }
+    })
+
+
+    if (authenticated) {
+        console.log('Authenticated');
+        return response
+    }
+    else if (!authenticated && !request.nextUrl.pathname.startsWith('/login')) {
+        console.log('Not authenticated');
+        return NextResponse.redirect(new URL(`/login?next=${redirectPage}`, request.url))
+    }
+}
+
+export const config = {
+    matcher: [
+        '/((?=tasks|pathways).*)'
+    ]
+}

--- a/src/utils/amplifyServerUtils.js
+++ b/src/utils/amplifyServerUtils.js
@@ -1,0 +1,13 @@
+import {createServerRunner} from "@aws-amplify/adapter-nextjs";
+import config from "MAIN/amplifyconfiguration.json";
+import {generateServerClientUsingCookies} from "@aws-amplify/adapter-nextjs/api";
+import {cookies} from "next/headers";
+
+export const {runWithAmplifyServerContext} = createServerRunner({
+    config
+})
+
+export const cookieBasedClient = generateServerClientUsingCookies({
+    config: config,
+    cookies
+})


### PR DESCRIPTION
Integrated our existing Amplify auth system with NextJS middleware to automatically handle redirecting for pages that require authentication. This will prevent us from having to add a check and redirect on every page that will require authentication. 

_Any page that needs auth can be added to the matcher within middleware.js:_
<img width="331" alt="Screenshot 2024-03-23 at 10 34 35 PM" src="https://github.com/UMLCloudComputing/UniPath.io/assets/81245965/c5f4345d-4991-4052-9487-1d9d3ef38144">

_In action:_
[https://imgur.com/a/uxDdMwr](url)