### PR TITLE
docs: updated readme for amplify gen2

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To run the application locally, you need to run the Amplify sandbox command to c
 Start the Amplify sandbox command. This will provision the AWS backend resources. Keep this command running in the background.
 
 ```sh
-npx amplify sandbox
+npx ampx sandbox
 ```
 
 Open a new terminal and start the frontend application:


### PR DESCRIPTION
#### Overall Review of Changes:
updated getting started to use new ```npx ampx sandbox``` command to start sandbox

##### Reason for Change
Needed since we updated our packages

#### Tested:
Yes
